### PR TITLE
Enabled GUI by default; Added 'cd' to clone repos in /home/vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure(2) do |config|
   #
   config.vm.provider "virtualbox" do |vb|
   #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
+      vb.gui = true
   #
      # Customize the amount of memory on the VM:
      # Git fails to clone the

--- a/setup_ubuntu1404.sh
+++ b/setup_ubuntu1404.sh
@@ -48,6 +48,8 @@ fi
 sudo ln -s $PWD/fel /usr/local/bin/fel
 popd
 
+cd /home/vagrant/
+
 echo -e "\n Installing CHIP-tools"
 git clone http://github.com/NextThingCo/CHIP-tools
 


### PR DESCRIPTION
Cloning the repos in the CHIP-SDK shared folder causes problems in Windows.