### PR TITLE
Fix setup script

### DIFF
--- a/setup_ubuntu1404.sh
+++ b/setup_ubuntu1404.sh
@@ -62,8 +62,8 @@ sunxi-fel
 sunxi-fexc
 sunxi-nand-part
 sunxi-pio
-pheonix_info
-nand-image-builder)
+phoenix_info
+sunxi-nand-image-builder)
 for BIN in ${SUNXI_TOOLS[@]};do
   if [[ -L /usr/local/bin/${BIN} ]]; then
     sudo rm /usr/local/bin/${BIN}


### PR DESCRIPTION
Found some spelling errors in the **setup_ubuntu1404.sh** script leading to error when creating NAND  images.

